### PR TITLE
Add optional output directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in itunes_csv.gemspec
-# use my fork of andyw8's version
-gem 'andyw8-itunes-library', git: 'https://github.com/smoreface/itunes-library.git'
-
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in itunes_csv.gemspec
+# use my fork of andyw8's version
+gem 'andyw8-itunes-library', git: 'https://github.com/smoreface/itunes-library.git'
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 
+# Specify your gem's dependencies in itunes_csv.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -16,38 +16,29 @@ I wanted to do a clean-up of my library. iTunes allows you to copy and paste fro
     Usage: itunes_csv [options]
         -f, --fields name,track,year     List of fields (default: name,artist)
         -p, --path PATH                  Path to iTunes XML file (default: ~/Music/iTunes/iTunes Music Library.xml)
+        -o, --output file                File to export the CSV file to (default: print to stdout)
 
 ## Notes
 
 May take a long time to run for a large iTunes library (10,000+ tracks)
 
-Supported fields:
+Supported fields are pulled from itunes-library track.rb file and include:
 
  * album
  * artist
- * audio?
- * audiobook?
- * composer
  * date_added
- * episode_number
  * genre
  * id
  * kind
  * last_played_at
  * location
- * location_path
- * movie?
- * number
  * persistent_id
  * play_count
- * played?
- * podcast?
- * season_number
- * total_time
- * tv_show?
- * unplayed?
- * video?
- * year
+ * comment
+ * duration_ms
+ * rating
+
+and others!
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -26,19 +26,30 @@ Supported fields are pulled from itunes-library track.rb file and include:
 
  * album
  * artist
+ * audio?
+ * audiobook?
+ * composer
  * date_added
+ * episode_number
  * genre
  * id
  * kind
  * last_played_at
  * location
+ * location_path
+ * movie?
+ * number
  * persistent_id
  * play_count
- * comment
- * duration_ms
- * rating
+ * played?
+ * podcast?
+ * season_number
+ * total_time
+ * tv_show?
+ * unplayed?
+ * video?
+ * year
 
-and others!
 
 ## Contributing
 

--- a/itunes_csv.gemspec
+++ b/itunes_csv.gemspec
@@ -16,7 +16,4 @@ Gem::Specification.new do |gem|
   gem.version       = ItunesCsv::VERSION
   gem.add_runtime_dependency "andyw8-itunes-library", "~> 0.1.3"
   gem.add_runtime_dependency "csv"
-  gem.metadata      = {
-    "source_code_uri" => "https://github.com/smoreface/itunes-library"
-  }
 end

--- a/itunes_csv.gemspec
+++ b/itunes_csv.gemspec
@@ -15,4 +15,8 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ItunesCsv::VERSION
   gem.add_runtime_dependency "andyw8-itunes-library", "~> 0.1.3"
+  gem.add_runtime_dependency "csv"
+  gem.metadata      = {
+    "source_code_uri" => "https://github.com/smoreface/itunes-library"
+  }
 end

--- a/lib/itunes_csv.rb
+++ b/lib/itunes_csv.rb
@@ -18,15 +18,21 @@ module ItunesCsv
         opts.on( '-p', '--path PATH', "Path to iTunes XML file (default: #{options[:path]})" ) do |path|
           options[:path] = path
         end
+
+        options[:output] = nil
+        opts.on( '-o', '--output FILE', "Output to FILE instead of stdout" ) do |file|
+          options[:output] = file
+        end
       end
 
-      opts.parse!
+      opts.parse!(args)
 
       library_path = File.expand_path(options[:path])
       library = ITunes::Library.load(library_path)
+      
       csv_string = CSV.generate do |csv|
         csv << options[:fields]
-      	library.music.tracks.each do |t|
+        library.music.tracks.each do |t|
           row = options[:fields].map do |f|
             unless t.respond_to?(f.to_sym)
               puts "Unknown field: #{f}"
@@ -34,10 +40,16 @@ module ItunesCsv
             end
             t.send(f.to_sym)
           end
-  		    csv << row
-  		  end
-  	  end
-  	  puts csv_string
+          csv << row
+        end
+      end
+      
+      if options[:output]
+        File.write(options[:output], csv_string)
+        puts "CSV written to #{options[:output]}"
+      else
+        puts csv_string
+      end
     end
   end
 end

--- a/lib/itunes_csv.rb
+++ b/lib/itunes_csv.rb
@@ -30,9 +30,12 @@ module ItunesCsv
       library_path = File.expand_path(options[:path])
       library = ITunes::Library.load(library_path)
       
+      total_tracks = library.music.tracks.count
+      puts "Processing #{total_tracks} tracks..."
+      
       csv_string = CSV.generate do |csv|
         csv << options[:fields]
-        library.music.tracks.each do |t|
+        library.music.tracks.each_with_index do |t, index|
           row = options[:fields].map do |f|
             unless t.respond_to?(f.to_sym)
               puts "Unknown field: #{f}"
@@ -41,8 +44,15 @@ module ItunesCsv
             t.send(f.to_sym)
           end
           csv << row
+          
+          # Print progress every 100 tracks
+          if (index + 1) % 100 == 0
+            puts "Processed #{index + 1}/#{total_tracks} tracks..."
+          end
         end
       end
+      
+      puts "Completed processing #{total_tracks} tracks."
       
       if options[:output]
         File.write(options[:output], csv_string)

--- a/lib/itunes_csv.rb
+++ b/lib/itunes_csv.rb
@@ -20,7 +20,7 @@ module ItunesCsv
         end
 
         options[:output] = nil
-        opts.on( '-o', '--output FILE', "Output to FILE instead of stdout" ) do |file|
+        opts.on( '-o', '--output FILE', "Output to FILE instead of stdout (default: stdout)" ) do |file|
           options[:output] = file
         end
       end
@@ -30,12 +30,9 @@ module ItunesCsv
       library_path = File.expand_path(options[:path])
       library = ITunes::Library.load(library_path)
       
-      total_tracks = library.music.tracks.count
-      puts "Processing #{total_tracks} tracks..."
-      
       csv_string = CSV.generate do |csv|
         csv << options[:fields]
-        library.music.tracks.each_with_index do |t, index|
+        library.music.tracks.each do |t|
           row = options[:fields].map do |f|
             unless t.respond_to?(f.to_sym)
               puts "Unknown field: #{f}"
@@ -44,15 +41,8 @@ module ItunesCsv
             t.send(f.to_sym)
           end
           csv << row
-          
-          # Print progress every 100 tracks
-          if (index + 1) % 100 == 0
-            puts "Processed #{index + 1}/#{total_tracks} tracks..."
-          end
         end
       end
-      
-      puts "Completed processing #{total_tracks} tracks."
       
       if options[:output]
         File.write(options[:output], csv_string)


### PR DESCRIPTION
Add an optional flag for an output directory:

- Update README with guidance
- Add a dependency of 'csv' because that is no longer included in ruby 3.4+
- Add optional output flag to the CLI command that writes the CSV strings to a file.

Tested locally both with and without an output directory specified using Ruby 3.4.7. 

Full disclosure, Claude helped me write the file output syntax and promptly made me feel silly for doing that at all because it was so simple. 